### PR TITLE
[Lesson 5] Updated tilestrata-mapnik

### DIFF
--- a/tileserver/package.json
+++ b/tileserver/package.json
@@ -13,7 +13,7 @@
     "tilestrata": "^2.0.1",
     "tilestrata-dependency": "^0.4.1",
     "tilestrata-disk": "^0.5.0",
-    "tilestrata-mapnik": "^0.3.0"
+    "tilestrata-mapnik": "^0.4.0"
   },
   "devDependencies": {
     "async": "^1.5.0",

--- a/tileserver/server.js
+++ b/tileserver/server.js
@@ -11,7 +11,7 @@ strata.layer('basemap')
     .route('tile.png')
         .use(disk.cache({dir: './basemap'}))
         .use(mapnik({
-            xml: './osm-bright/OSMBright/mapnik.xml',
+            pathname: './osm-bright/OSMBright/mapnik.xml',
             tileSize: 256,
             scale: 1
         }))


### PR DESCRIPTION
We released [0.4.0](https://github.com/naturalatlas/tilestrata-mapnik/releases/tag/v0.4.0) last night which contains a breaking change (`pathname` vs `xml`). Updating this should hopefully prevent some confusion if someone does `npm install tilestrata-mapnik` on their own :)
